### PR TITLE
Use bash over sh

### DIFF
--- a/hooks/on-exit-sync
+++ b/hooks/on-exit-sync
@@ -47,4 +47,4 @@ MESSAGE=$(echo -e "${COMMAND}\n\n----------\n${CONTEXT}\n----------\n\nThis mess
 git -C "${GIT_REPO}" commit -a -m "${MESSAGE}" >/dev/null 2>&1
 
 # Now let's use git-sync in background.
-(cd "${GIT_REPO}" && sh git-sync) &>>"${LOG_FILE}" & disown
+(cd "${GIT_REPO}" && bash git-sync) &>>"${LOG_FILE}" & disown


### PR DESCRIPTION
Force usage of bash, else it fails if sh points to POSIX compliant shell (like dash).
![2024-04-29_22-11-34_apn](https://github.com/xingheng/taskwarrior-data/assets/4533248/1547b463-c97b-4318-bf63-fd7c58311315)
